### PR TITLE
add touchscreen as touchpad (button only)

### DIFF
--- a/switch/src/host.cpp
+++ b/switch/src/host.cpp
@@ -337,6 +337,13 @@ bool Host::ReadGameKeys(SDL_Event *event, ChiakiControllerState *state){
 					ret = false;
 			}
 			break;
+        case SDL_FINGERDOWN:
+            state->buttons |= CHIAKI_CONTROLLER_BUTTON_TOUCHPAD; // touchscreen
+            break;
+        case SDL_FINGERUP:
+            state->buttons ^= CHIAKI_CONTROLLER_BUTTON_TOUCHPAD; // touchscreen
+            break;
+
 #endif
 		default:
 			ret = false;


### PR DESCRIPTION
I don't think mainline chiaki currently supports full touchpad support for swipes, pressing different corners etc, only as a button. This adds support to use that button by touching the Switch's touchscreen. Tested working with The Last Of Us.