### PR TITLE
Set workdir in docker build script

### DIFF
--- a/scripts/switch/run-docker-build-chiaki.sh
+++ b/scripts/switch/run-docker-build-chiaki.sh
@@ -4,7 +4,8 @@ cd "`dirname $(readlink -f ${0})`/../.."
 
 docker run \
 	-v "`pwd`:/build/chiaki" \
+	-w "/build/chiaki" \
 	-t \
 	chiaki-switch \
-	-c "cd /build/chiaki && scripts/switch/build.sh"
+	-c "scripts/switch/build.sh"
 


### PR DESCRIPTION
The best practice in docker is to use `-w` param instead of `cd <dir> && <command>`